### PR TITLE
fix error when specifiying static tags, add jshint, misc cleanup

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+    "globals" : {
+        "console" : "undefined"
+    },
+    "predef": [ "-Promise" ],
+    "bitwise": true,
+    "curly": true,
+    "eqeqeq" : true,
+    "expr" : true,
+    "immed": true,
+    "latedef" : false,
+    "laxbreak": true,
+    "loopfunc" : true,
+    "newcap" : false,
+    "noarg": true,
+    "node": true,
+    "scripturl" : true,
+    "strict" : false,
+    "smarttabs": true,
+    "sub": true,
+    "undef" : true,
+    "unused": "vars"
+}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will send a metric to the Jut system with the name `pizza`,
 tagged with `topping=pepperoni` and `diameter_inches=18`. This is in
 addition to any standard tags that are applied to every point. Note
 that some tags are reserved for internal use (please see
-`RESERVED_TAGS` in `lib/jut.js`).
+`RESERVED_TAGS` in `lib/parse.js`).
 
 Testing
 -------

--- a/lib/jut.js
+++ b/lib/jut.js
@@ -1,4 +1,6 @@
-var build_metric = require('./parse').build_metric;
+var Parse = require('./parse');
+var build_metric = Parse.build_metric;
+var RESERVED_TAGS = Parse.RESERVED_TAGS;
 var sender = require('./send-receiver');
 var active_sender;
 
@@ -97,7 +99,7 @@ exports.init = function init(startup_time, config, events, logger_in) {
     jut_stats.lastFlush = Date.now() / 1000;
     jut_stats.lastException = Date.now() / 1000;
 
-    active_sender.init(config, jut_stats);
+    active_sender.init(config, jut_stats, logger);
 
     events.on('flush', flush_metrics);
     events.on('status', status);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -12,6 +12,8 @@ var RESERVED_TAGS = {
     interval: true,
 };
 
+exports.RESERVED_TAGS = RESERVED_TAGS;
+
 function _parse_split(key) {
     var parts = key.split('.');
     if (parts.length === 0) {

--- a/lib/send-receiver.js
+++ b/lib/send-receiver.js
@@ -3,6 +3,7 @@
 
 var http = require('http');
 var url = require('url');
+var logger;
 
 var jut_stats;
 var options = {
@@ -11,8 +12,9 @@ var options = {
 
 var http_opts;
 
-exports.init = function init(config, jut_stats_in) {
+exports.init = function init(config, jut_stats_in, logger_in) {
     jut_stats = jut_stats_in;
+    logger = logger_in;
 
     var jut_config = config.jut || {};
     options.debug = !!config.debug;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-jut-backend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Jut backend for StatsD",
   "repository": {
     "type": "git",
@@ -20,10 +20,12 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^3.0.0",
+    "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "underscore": "^1.8.3"
   },
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "node_modules/mocha/bin/mocha",
+    "lint": "node_modules/jshint/bin/jshint -c .jshintrc lib/*.js test/*.js"
   }
 }

--- a/test/mock-server-data.js
+++ b/test/mock-server-data.js
@@ -50,7 +50,9 @@ module.exports = {
                     "value": 42,
                     "source_type": "metric",
                     "stat": "sum",
-                    "interval": 10000
+                    "interval": 10000,
+                    "cats": "cute",
+                    "lives": 9
                 },
                 {
                     "metric_type": "counter",
@@ -59,7 +61,9 @@ module.exports = {
                     "value": 4.2,
                     "source_type": "metric",
                     "stat": "rate",
-                    "interval": 10000
+                    "interval": 10000,
+                    "cats": "cute",
+                    "lives": 9
                 }
             ],
         },
@@ -166,7 +170,9 @@ module.exports = {
                     "time": 987000,
                     "value": 4,
                     "source_type": "metric",
-                    "interval": 10000
+                    "interval": 10000,
+                    "cats": "cute",
+                    "lives": 9
                 },
                 {
                     "metric_type": "gauge",
@@ -178,7 +184,9 @@ module.exports = {
                     "time": 987000,
                     "value": 27,
                     "source_type": "metric",
-                    "interval": 10000
+                    "interval": 10000,
+                    "cats": "cute",
+                    "lives": 9
                 },
                 {
                     "metric_type": "gauge",
@@ -189,7 +197,9 @@ module.exports = {
                     "time": 987000,
                     "value": 17,
                     "source_type": "metric",
-                    "interval": 10000
+                    "interval": 10000,
+                    "cats": "cute",
+                    "lives": 9
                 }
             ],
         },

--- a/test/test-sender.js
+++ b/test/test-sender.js
@@ -1,4 +1,3 @@
-var send_callback;
 var events;
 
 exports.init = function init(config, jut_stats_in) {


### PR DESCRIPTION
fix error when specifying static tags, add jshint, misc cleanup

This fixes a fatal error that would occur when extra tags were
specified. It also adds unit tests for this. In addition, there
is some miscellaneous cleanup. To prevent errors like this from
occurring in the future, a jshint config was added for dev mode.
