### PR TITLE
changes for connectors and reusability

### DIFF
--- a/lib/jut.js
+++ b/lib/jut.js
@@ -69,6 +69,8 @@ function status(callback) {
     });
 }
 
+exports.Parse = Parse;
+
 exports.init = function init(startup_time, config, events, logger_in) {
     logger = logger_in;
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -70,7 +70,7 @@ exports.build_metric = function build_metric(options, metric_type, name, timesta
 
     _copy_tags(metric, options.extra_tags);
 
-    metric.time = timestamp;
+    metric.time = new Date(timestamp).toISOString();
     metric.value = value;
     metric.source_type = 'metric';
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -14,7 +14,7 @@ var RESERVED_TAGS = {
 
 exports.RESERVED_TAGS = RESERVED_TAGS;
 
-function _parse_split(key) {
+function parse_split(key) {
     var parts = key.split('.');
     if (parts.length === 0) {
         return {key: key, tags: []};
@@ -56,7 +56,7 @@ exports.build_metric = function build_metric(options, metric_type, name, timesta
 
     // extract tags from metric name, if enabled
     if (options.split_keys) {
-        o = _parse_split(name);
+        o = parse_split(name);
         metric = o.tags;
         metric.name = o.key;
     }
@@ -80,3 +80,5 @@ exports.build_metric = function build_metric(options, metric_type, name, timesta
 
     return metric;
 };
+
+exports.parse_split = parse_split;

--- a/lib/send-receiver.js
+++ b/lib/send-receiver.js
@@ -2,6 +2,8 @@
 // receiver
 
 var http = require('http');
+var https = require('https');
+var request_fn;
 var url = require('url');
 var logger;
 
@@ -31,6 +33,21 @@ exports.init = function init(config, jut_stats_in, logger_in) {
         'Content-Type': 'application/json',
     };
     http_opts.agent = false;
+    http_opts.rejectUnauthorized = true;
+
+    if (config.jut.insecure_https) {
+        http_opts.rejectUnauthorized = false;
+    }
+
+    if (http_opts.protocol === 'https:') {
+        request_fn = https.request;
+    }
+    else if (http_opts.protocol === 'http:') {
+        request_fn = http.request;
+    }
+    else {
+        throw new Error('invalid protocol ' + http_opts.protocol);
+    }
 };
 
 exports.send = function send(payload) {
@@ -40,7 +57,9 @@ exports.send = function send(payload) {
 
     var post_body = JSON.stringify(payload);
 
-    var req = http.request(http_opts, function(res) {
+    http_opts.headers['Content-Length'] = post_body.length;
+
+    var req = request_fn(http_opts, function(res) {
 
         var res_body = '';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-jut-backend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Jut backend for StatsD",
   "repository": {
     "type": "git",


### PR DESCRIPTION
changes for connectors and reusability

This branch adds some changes to properly support the direct
connector. First is supports sending to an HTTPS endpoint,
optionally accepting invalid certificates for testing
purposes. Second, it sends time fields in ISO8601 format instead
of epoch milliseconds.

In addition, it exports `parse.js` and `parse_split()`, so these
functions can be reused.
