### PR TITLE
change stat tags for counters, allow overriding some internal tags

### DIFF
--- a/lib/jut.js
+++ b/lib/jut.js
@@ -30,7 +30,7 @@ function flush_metrics(timestamp, metrics) {
 
     // send counters
     for (key in counters) {
-        payload.push(build_metric(options, 'counter', key, timestamp, counters[key], 'sum'));
+        payload.push(build_metric(options, 'counter', key, timestamp, counters[key], 'delta'));
     }
 
     // send gauges

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,6 +2,7 @@
 // suitable for sending to Jut. It optionally supports arbitrary
 // key-value pairs embedded in the metric name.
 
+// tags that aren't allowed in static config
 var RESERVED_TAGS = {
     time: true,
     value: true,
@@ -10,6 +11,14 @@ var RESERVED_TAGS = {
     stat: true,
     name: true,
     interval: true,
+};
+
+// tags that aren't allowed with split_tags=true
+var NO_OVERRIDE_TAGS = {
+    time: true,
+    value: true,
+    interval: true,
+    name: true,
 };
 
 exports.RESERVED_TAGS = RESERVED_TAGS;
@@ -24,7 +33,7 @@ function parse_split(key) {
     var tags = {};
     parts.forEach(function(p) {
         var tag = p.split('__');
-        if (tag.length === 2 && tag[0] !== '' && !RESERVED_TAGS[tag[0]]) {
+        if (tag.length === 2 && tag[0] !== '' && !NO_OVERRIDE_TAGS[tag[0]]) {
             tags[tag[0]] = tag[1];
         }
         else {
@@ -66,17 +75,21 @@ exports.build_metric = function build_metric(options, metric_type, name, timesta
         };
     }
 
-    metric.metric_type = metric_type;
+    // allow overriding some params with tags
+    if (typeof metric.metric_type === 'undefined') {
+        metric.metric_type = metric_type;
+    }
+    if (typeof metric.source_type === 'undefined') {
+        metric.source_type = 'metric';
+    }
+    if (stat_type && typeof metric.stat === 'undefined') {
+        metric.stat = stat_type;
+    }
 
     _copy_tags(metric, options.extra_tags);
 
     metric.time = new Date(timestamp).toISOString();
     metric.value = value;
-    metric.source_type = 'metric';
-
-    if (stat_type) {
-        metric.stat = stat_type;
-    }
 
     return metric;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-jut-backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Jut backend for StatsD",
   "repository": {
     "type": "git",

--- a/test/mock-server-data.js
+++ b/test/mock-server-data.js
@@ -19,7 +19,7 @@ module.exports = {
                     "time": 123000,
                     "value": 42,
                     "source_type": "metric",
-                    "stat": "sum",
+                    "stat": "delta",
                     "interval": 10000
                 }
             ],
@@ -49,7 +49,7 @@ module.exports = {
                     "time": 123000,
                     "value": 42,
                     "source_type": "metric",
-                    "stat": "sum",
+                    "stat": "delta",
                     "interval": 10000,
                     "cats": "cute",
                     "lives": 9

--- a/test/mock-server-data.js
+++ b/test/mock-server-data.js
@@ -98,6 +98,35 @@ module.exports = {
             body: 'OK',
         }
     },
+    override_internal_tags: {
+        input: {
+            timestamp: 456,
+            metrics: {
+                counters: {
+                    "bar.metric_type__notacounter.stat__neato.source_type__totallynotametric": 42
+                }
+            }
+        },
+        request: {
+            body: [
+                {
+                    "metric_type": "notacounter",
+                    "stat": "neato",
+                    "name": "bar",
+                    "time": 456000,
+                    "value": 42,
+                    "source_type": "totallynotametric",
+                    "interval": 10000,
+                    "cats": "cute",
+                    "lives": 9
+                }
+            ],
+        },
+        response: {
+            status: 200,
+            body: 'OK',
+        }
+    },
     timer_with_stats: {
         input: {
             timestamp: 789,

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -294,6 +294,13 @@ describe('jut statsd backend mock receiver tests', function() {
         mock_receiver.events.once('done', done);
     });
 
+    it('is able to override some internal tags', function(done) {
+        mock_receiver.current_test = 'override_internal_tags';
+        emit_event('override_internal_tags');
+
+        mock_receiver.events.once('done', done);
+    });
+
     it('initializes the backend module with invalid extra tags', function() {
         events = new EventEmitter();
 


### PR DESCRIPTION
This branch introduces two small changes.

First, for StatsD counters, the `stat` tag is reported as `delta`
instead of `sum`. This is a more accurate description.

Second, it is now possible to override some internal tags when
using `split_tags`. Now `metric_type`, `source_type`, and `stat`
can be overridden if encoded as key-value pairs in the metric
name.
