### PR TITLE
fix stats command

### DIFF
--- a/lib/jut.js
+++ b/lib/jut.js
@@ -64,10 +64,12 @@ function flush_metrics(timestamp, metrics) {
 }
 
 function status(callback) {
-    jut_stats.keys().forEach(function(key) {
+    Object.keys(jut_stats).forEach(function(key) {
         callback(null, 'jut', key, jut_stats[key]);
     });
 }
+
+exports.status = status;
 
 exports.Parse = Parse;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-jut-backend",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Jut backend for StatsD",
   "repository": {
     "type": "git",

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -330,6 +330,30 @@ describe('jut statsd backend mock receiver tests', function() {
         throw new Error('this test should fail');
     });
 
+    it('checks some stats', function(done) {
+        var seen_flush = false;
+        var seen_exception = false;
+
+        function check_stats(key, value) {
+            if (key === 'lastFlush') {
+                seen_flush = true;
+                expect(value * 1000).to.be.at.most(Date.now());
+            }
+            else if (key === 'lastException') {
+                seen_exception = true;
+                expect(value * 1000).to.be.at.most(Date.now());
+            }
+
+            if (seen_flush && seen_exception) {
+                done();
+            }
+        }
+
+        jut_statsd_backend.status(function(a, backend, key, value) {
+            check_stats(key, value);
+        });
+    });
+
     after(function(done) {
         mock_receiver.stop(done);
     });


### PR DESCRIPTION
fix stats command

Due to a coding mistake, the `stats` command on the StatsD
management port was broken. This fixes the mistake and adds a
unit test for the `status` method.
